### PR TITLE
fix(ci): add --ignore-npm-errors to frontend SBOM generation

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -53,6 +53,7 @@ jobs:
         run: |
           cyclonedx-npm \
             --package-lock-only \
+            --ignore-npm-errors \
             --output-format JSON \
             --output-file sbom-output/sbom-frontend.cdx.json \
             frontend/package.json


### PR DESCRIPTION
cyclonedx-npm runs `npm ls` internally, which fails with ELSPROBLEMS
when peer dependency ranges aren't satisfied (eslint@10, typescript@6,
picomatch@2.3.2). These conflicts are accepted — frontend/.npmrc sets
legacy-peer-deps=true — but npm ls doesn't honour that flag.

Adding --ignore-npm-errors makes the tool emit warnings and continue
rather than exiting 254, restoring the SBOM & AIBOM CI workflow.

https://claude.ai/code/session_01Q5F5Nr63SNxVyVRHjfHtMb