### PR TITLE
chore: release v4.2.1 — CI improvements + release changelog publishing

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -73,20 +73,66 @@ jobs:
           echo "version=${TAG}" >> "$GITHUB_OUTPUT"
 
   # ────────────────────────────────────────────────────────────────────────────
+  # Create (or update) the GitHub Release and populate it with release notes
+  # extracted from RELEASE_NOTES.md so the Explore feed shows a rich card.
+  # ────────────────────────────────────────────────────────────────────────────
+  create-release:
+    name: Create GitHub Release with changelog
+    runs-on: ubuntu-latest
+    needs: [check-release]
+    if: |
+      always() && (
+        (needs.check-release.result == 'success' && needs.check-release.outputs.should_release == 'true') ||
+        needs.check-release.result == 'skipped'
+      )
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Determine release version
+        id: version
+        run: |
+          if [ -n "${{ needs.check-release.outputs.version }}" ]; then
+            echo "tag=${{ needs.check-release.outputs.version }}" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ github.event.inputs.version }}" ]; then
+            echo "tag=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract changelog for this version
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          BARE="${TAG#v}"
+          awk "/^## \[${BARE}\]/{found=1; next} found && /^## \[/{exit} found{print}" RELEASE_NOTES.md \
+            | sed '/^[[:space:]]*$/{ N; /^\n[[:space:]]*$/d }' > /tmp/release-notes.md || true
+          if [ ! -s /tmp/release-notes.md ]; then
+            printf "See [RELEASE_NOTES.md](https://github.com/%s/blob/main/RELEASE_NOTES.md) for full details.\n" \
+              "${{ github.repository }}" > /tmp/release-notes.md
+          fi
+
+      - name: Publish release with changelog
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
+          body_path: /tmp/release-notes.md
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ────────────────────────────────────────────────────────────────────────────
   # Build Windows installer (.exe)
   # ────────────────────────────────────────────────────────────────────────────
   build-windows:
     name: Windows Installer (.exe)
     runs-on: windows-latest
     timeout-minutes: 30
-    needs: [check-release]
-    # Run when: (a) check-release said yes, (b) check-release was skipped
-    # because the trigger wasn't push-to-main (tag / release / dispatch).
-    if: |
-      always() && (
-        (needs.check-release.result == 'success' && needs.check-release.outputs.should_release == 'true') ||
-        needs.check-release.result == 'skipped'
-      )
+    needs: [check-release, create-release]
+    if: always() && needs.create-release.result == 'success'
 
     permissions:
       contents: write   # needed to upload release assets
@@ -259,12 +305,8 @@ jobs:
     name: macOS Installer (.dmg — arm64)
     runs-on: macos-latest
     timeout-minutes: 20
-    needs: [check-release]
-    if: |
-      always() && (
-        (needs.check-release.result == 'success' && needs.check-release.outputs.should_release == 'true') ||
-        needs.check-release.result == 'skipped'
-      )
+    needs: [check-release, create-release]
+    if: always() && needs.create-release.result == 'success'
 
     permissions:
       contents: write
@@ -365,12 +407,8 @@ jobs:
     name: macOS Installer (.dmg — x64)
     runs-on: macos-13
     timeout-minutes: 20
-    needs: [check-release]
-    if: |
-      always() && (
-        (needs.check-release.result == 'success' && needs.check-release.outputs.should_release == 'true') ||
-        needs.check-release.result == 'skipped'
-      )
+    needs: [check-release, create-release]
+    if: always() && needs.create-release.result == 'success'
 
     permissions:
       contents: write
@@ -468,12 +506,8 @@ jobs:
     name: Linux AppImage
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [check-release]
-    if: |
-      always() && (
-        (needs.check-release.result == 'success' && needs.check-release.outputs.should_release == 'true') ||
-        needs.check-release.result == 'skipped'
-      )
+    needs: [check-release, create-release]
+    if: always() && needs.create-release.result == 'success'
 
     permissions:
       contents: write

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,18 @@
 
 ---
 
+## [4.2.1] — 2026-05-27
+
+### Fixed
+
+- **CI version-sync gate**: added a fast, no-install job (`check-version-sync` in `security.yml`) that reads all three `package.json` files and fails the PR immediately if any version is out of step. Previously a missed bump caused `build-release.yml`'s `check-release` gate to silently skip all installer builds.
+
+### Changed
+
+- **GitHub Release changelogs**: releases now include the full matching `RELEASE_NOTES.md` section as the release body, so the entry is rendered on the GitHub Explore/Activity feed with a rich card instead of appearing blank. A new `create-release` job in `build-release.yml` extracts and publishes the notes before the platform-specific build jobs run.
+
+---
+
 ## [4.2.0] — 2026-05-24
 
 ### Added

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "controlweave-backend",
-  "version": "4.0.1",
+  "version": "4.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "controlweave-backend",
-      "version": "4.0.1",
+      "version": "4.2.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.98.0",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12186,9 +12186,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "controlweave-backend",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "license": "AGPL-3.0",
   "engines": {
     "node": ">=20.16.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -144,6 +144,7 @@
     "follow-redirects": "^1.16.0",
     "uuid": "^14.0.0",
     "qs": ">=6.15.2",
-    "@tootallnate/once": ">=2.0.1"
+    "@tootallnate/once": ">=2.0.1",
+    "tmp": ">=0.2.6"
   }
 }

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "controlweave-desktop",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "ControlWeave AI GRC Platform — Desktop Edition",
   "author": "ControlWeave <contehconsulting@gmail.com>",
   "license": "AGPL-3.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "controlweave-frontend",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "controlweave-frontend",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
@@ -1541,6 +1541,72 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "controlweave-frontend",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "license": "AGPL-3.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

Patch release **v4.2.1** on top of v4.2.0. Includes all features shipped in v4.2.0 (custom frameworks, executive analytics, MSP hierarchy, continuous-monitoring connectors, CIS Controls v8, FedRAMP High) plus two CI improvements made after that tag.

### What's new in 4.2.1

- **GitHub Release changelogs** — a new `create-release` job in `build-release.yml` extracts the matching `RELEASE_NOTES.md` section and sets it as the release body before the platform build jobs run. Releases now render a rich card in the GitHub Explore/Activity feed instead of appearing blank.
- **Version-sync CI gate** — `check-version-sync` in `security.yml` reads all three `package.json` files and fails the PR immediately if any version is out of step. Catches the class of mistake where one file is missed during a release bump (previously caused `check-release` to silently skip all installer builds).

### What's included from v4.2.0

- Custom Compliance Framework Builder (migrations 113, new API + frontend page)
- Advanced Analytics & Scheduled Reporting (migrations 114, executive dashboard, cron snapshot script)
- MSP Multi-Tenant Org Hierarchy (migration 115, managed-orgs dashboard, delegated admins)
- Continuous Monitoring Connectors: AWS Security Hub, Qualys VMDR, ServiceNow ITSM
- CIS Controls v8 and FedRAMP High Baseline framework seeds + 203 crosswalk mappings
- FedRAMP Deployment Guide (`docs/FEDRAMP_DEPLOYMENT_GUIDE.md`)
- CNSA Suite 1.0/2.0 cryptographic alignment (HS384, SHA-384, ML-DSA-65)
- openid-client v6 migration for SSO
- Full de-tier / open-source parity (all `requireTier` guards removed)
- Dependency bumps: `@anthropic-ai/sdk` 0.98.0, `@sentry/node` 10.53.1, `tailwindcss` 4.3.0, `node-cron` 4.2.1, `lucide-react` 1.16.0, `@playwright/test` 1.60.0

## Version sync

| Package | Version |
|---|---|
| `backend/package.json` | 4.2.1 |
| `frontend/package.json` | 4.2.1 |
| `electron/package.json` | 4.2.1 |
| `RELEASE_NOTES.md` | `## [4.2.1] — 2026-05-27` |

## Test plan

- [ ] `cd backend && npm run check:syntax` passes
- [ ] `cd backend && npm run build` passes
- [ ] `cd backend && npm audit --audit-level=moderate` exits 0
- [ ] `cd backend && npx jest` passes
- [ ] `cd frontend && npm run typecheck` passes
- [ ] `cd frontend && npm audit --audit-level=moderate` exits 0
- [ ] After merge, tag `v4.2.1` → `build-release.yml` fires and `create-release` job populates the release body from `RELEASE_NOTES.md`

https://claude.ai/code/session_01AQ6hodP59FbnXfCcBWSCfp

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQ6hodP59FbnXfCcBWSCfp)_