### PR TITLE
security(audit): add append-only enforcement, timestamptz, outcome integrity

### DIFF
--- a/backend/migrations/152_audit_logs_timestamptz.sql
+++ b/backend/migrations/152_audit_logs_timestamptz.sql
@@ -1,0 +1,72 @@
+-- Migration 152: Convert audit_logs.created_at to timestamptz (NIST AU-8)
+--
+-- AU-8 (Time Stamps) requires audit records to carry timestamps that can be
+-- mapped to Coordinated Universal Time. audit_logs.created_at was created as
+-- TIMESTAMP WITHOUT TIME ZONE in 001_initial_schema.sql and is defaulted
+-- server-side by NOW(), so the recorded instant is only interpretable if the
+-- reader independently knows the database server's zone -- and nothing in the
+-- record states it. Two deployments in different zones produce audit trails
+-- that cannot be correlated, which is exactly what AU-8 exists to prevent.
+--
+-- This also brings the column in line with .claude/rules/database.md, whose
+-- data-type table specifies timestamptz and explicitly lists bare `timestamp`
+-- as the type to avoid. agent_audit_events (092) already uses TIMESTAMPTZ;
+-- audit_logs was the outlier.
+--
+-- The FedRAMP deployment guide previously claimed "All records use timestamptz
+-- (UTC)" for AU-8. That claim was corrected to describe the real type in the
+-- documentation pass that precedes this migration; this migration is what
+-- makes the original claim true.
+--
+-- CONVERSION SAFETY: existing rows were written by NOW() under a TIMESTAMP
+-- column, which captured the database server's local wall-clock time. The
+-- USING clause below interprets those stored values as UTC. That is correct
+-- for a server running UTC, which is the case for the containerized and
+-- Railway deployments this repo targets. Before applying to a deployment whose
+-- database is NOT in UTC, substitute the real zone in the USING clause --
+-- otherwise every historical timestamp shifts by the server's offset.
+-- Check with: SHOW timezone;
+--
+-- Ordering note: migration 153 in this same batch adds the append-only
+-- triggers this repository has been missing. This conversion runs first, while
+-- the table is still freely rewritable, so the two do not interact. (Even
+-- reversed it would be safe -- ALTER COLUMN TYPE is a table rewrite, not
+-- row-level DML, so a BEFORE UPDATE trigger would not fire -- but running the
+-- type change first avoids relying on that.)
+--
+-- Ships in the AU control family remediation batch.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'audit_logs'
+      AND column_name = 'created_at'
+      AND data_type = 'timestamp without time zone'
+  ) THEN
+    ALTER TABLE audit_logs
+      ALTER COLUMN created_at TYPE timestamptz
+      USING created_at AT TIME ZONE 'UTC';
+  END IF;
+END$$;
+
+COMMENT ON COLUMN audit_logs.created_at IS
+  'AU-8: instant the audit record was written, stored as timestamptz so it is unambiguously mappable to UTC. Set server-side by NOW() -- never supplied by the caller.';
+
+-- Document the two columns whose population is narrower than their presence
+-- suggests. Before this batch, services/auditService.js#extractAuditContext
+-- attempted to read both from the request and always got undefined -- the JWT
+-- payload carries only userId, the authenticate middleware selects neither
+-- column, and express-session is not a dependency. Those dead reads are
+-- removed in the same change; the columns are retained because
+-- authentication_method is genuinely populated by authentication events, and
+-- because request_id already provides per-request correlation for everything
+-- else.
+COMMENT ON COLUMN audit_logs.authentication_method IS
+  'Populated for authentication events only (password, sso), set explicitly by auditService.logAuthentication/logLogout. NULL on request-derived records -- not derivable from a request.';
+
+COMMENT ON COLUMN audit_logs.session_id IS
+  'Reserved. No writer populates this today: the platform issues stateless JWTs with no session identifier. Use request_id for per-request correlation.';
+
+SELECT 'Migration 152 completed.' AS result;

--- a/backend/migrations/153_audit_log_immutability.sql
+++ b/backend/migrations/153_audit_log_immutability.sql
@@ -1,0 +1,90 @@
+-- Migration 153: Enforce audit_logs immutability at the database level (NIST AU-9)
+--
+-- AU-9 (Protection of Audit Information) requires audit records to be
+-- protected from unauthorized modification and deletion. This repository had
+-- no such protection. README.md and PROJECT_STATUS.md described the audit log
+-- as "immutable" in five places, but the only thing standing between an audit
+-- record and a rewrite was that routes/audit.js happens not to expose an
+-- UPDATE or DELETE route. That is convention, not a control -- any other code
+-- path (a future route, a script, a psql session using the same application
+-- role) could freely rewrite or erase history. Those claims were corrected in
+-- the documentation pass preceding this migration; this migration is what
+-- makes them true again.
+--
+-- The row-level security policy added in 105_row_level_security.sql does not
+-- help here: it is USING-only, which governs which rows a session can see,
+-- not whether it may modify them.
+--
+-- This is a port of the sibling ControlWeaver-Pro repository's migration 121,
+-- which has been enforcing this for some time. The logic is intentionally
+-- identical so the two repositories do not drift on an audit control.
+--
+-- A trigger is used instead of REVOKE because this repo's hosted Postgres
+-- setups typically run the whole application under one owning role, and
+-- REVOKE has no effect on the object owner's own default privileges; a raised
+-- exception inside the trigger fires unconditionally for any writer
+-- regardless of role.
+--
+-- Scope of what this does and does not give you: the table becomes
+-- tamper-RESISTANT, not tamper-EVIDENT. The application owns the table and can
+-- therefore still issue ALTER TABLE ... DISABLE TRIGGER (the seed scripts do
+-- exactly that, see below). Detecting a mutation that got through requires a
+-- hash chain or an external write-once copy, neither of which exists yet.
+--
+-- Compatibility check performed before adding this: the only post-insert write
+-- to audit_logs anywhere in this repository is the siem_forwarded flag set by
+-- services/auditService.js:146, which the trigger explicitly permits. Unlike
+-- the sibling repository, no seed or reset script here issues DELETE FROM
+-- audit_logs, so nothing needed a trigger-disable wrapper. Any future script
+-- that must clear tagged demo rows has to wrap the call in
+-- `ALTER TABLE audit_logs DISABLE/ENABLE TRIGGER audit_logs_no_update`.
+--
+-- Ships in the AU control family remediation batch.
+
+CREATE OR REPLACE FUNCTION reject_audit_log_mutation()
+RETURNS TRIGGER AS $$
+DECLARE
+  old_with_new_flag audit_logs;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'audit_logs is append-only (AU-9): DELETE is not permitted'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF TG_OP = 'TRUNCATE' THEN
+    RAISE EXCEPTION 'audit_logs is append-only (AU-9): TRUNCATE is not permitted'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- TG_OP = 'UPDATE': only the siem_forwarded metadata flag may change
+  -- post-insert. It is set by services/auditService.js#forwardToSiem() once an
+  -- event is confirmed delivered to the configured SIEM, and is the single
+  -- legitimate post-insert write. Any change to a forensic field is rejected.
+  old_with_new_flag := OLD;
+  old_with_new_flag.siem_forwarded := NEW.siem_forwarded;
+
+  IF old_with_new_flag IS DISTINCT FROM NEW THEN
+    RAISE EXCEPTION 'audit_logs is append-only (AU-9): only siem_forwarded may be updated post-insert'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS audit_logs_no_update ON audit_logs;
+CREATE TRIGGER audit_logs_no_update
+  BEFORE UPDATE OR DELETE ON audit_logs
+  FOR EACH ROW
+  EXECUTE FUNCTION reject_audit_log_mutation();
+
+DROP TRIGGER IF EXISTS audit_logs_no_truncate ON audit_logs;
+CREATE TRIGGER audit_logs_no_truncate
+  BEFORE TRUNCATE ON audit_logs
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION reject_audit_log_mutation();
+
+COMMENT ON FUNCTION reject_audit_log_mutation() IS
+  'AU-9: blocks DELETE/TRUNCATE on audit_logs and restricts UPDATE to the siem_forwarded flag only, so the table is append-only regardless of caller privileges.';
+
+SELECT 'Migration 153 completed.' AS result;

--- a/backend/src/middleware/auditLog.js
+++ b/backend/src/middleware/auditLog.js
@@ -68,7 +68,6 @@ function auditLog(eventType, options = {}) {
           ipAddress: extractIpFromRequest(req),
           userAgent: req.headers['user-agent'] || null,
           success: true,
-          sessionId: req.sessionId || null,
           requestId: req.requestId || null,
           actorName: user.username || user.email || null
         }).catch(err => {

--- a/backend/src/routes/audit.js
+++ b/backend/src/routes/audit.js
@@ -16,6 +16,17 @@ const auditWriteLimiter = createRateLimiter({
   max: 60
 });
 
+// Valid values for audit_logs.outcome, per the column comment set in
+// migration 048. The legacy boolean audit_logs.success is derived from this
+// rather than accepted independently: the two describe the same fact, and
+// letting a caller set them separately allowed a record asserting
+// success = true alongside outcome = 'failure'. 'partial' maps to
+// success = false -- a partially completed action is not a success, and for
+// an audit record under-claiming is the safer direction.
+const AUDIT_OUTCOMES = ['success', 'failure', 'partial'];
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 // express-rate-limit applied router-wide, ahead of authenticate, so a cheap
 // IP-based bound is in place before authenticate's own DB/JWT work runs, and
 // so static analysis (CodeQL) can trace a recognized rate-limiting
@@ -231,6 +242,20 @@ router.post('/logs', auditWriteLimiter, requirePermission('audit.write'), async 
       return res.status(400).json({ success: false, error: 'event_type is required (string, max 100 chars).' });
     }
 
+    const resolvedOutcome = outcome || 'success';
+    if (!AUDIT_OUTCOMES.includes(resolvedOutcome)) {
+      return res.status(400).json({
+        success: false,
+        error: `outcome must be one of: ${AUDIT_OUTCOMES.join(', ')}.`
+      });
+    }
+
+    // resource_id is a UUID column -- reject a malformed value here rather than
+    // letting the driver raise and surface as an opaque 500.
+    if (resource_id && !UUID_PATTERN.test(String(resource_id))) {
+      return res.status(400).json({ success: false, error: 'resource_id must be a UUID.' });
+    }
+
     // Parse details — accept string (JSON) or object
     let parsedDetails = {};
     if (details) {
@@ -245,8 +270,8 @@ router.post('/logs', auditWriteLimiter, requirePermission('audit.write'), async 
       `INSERT INTO audit_logs
        (organization_id, user_id, event_type, resource_type, resource_id, details,
         ip_address, user_agent, success, outcome, source_system, created_at)
-       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, true, $9, $10, NOW())
-       RETURNING id, event_type, created_at`,
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9, $10, $11, NOW())
+       RETURNING id, event_type, outcome, success, created_at`,
       [
         orgId,
         userId,
@@ -256,7 +281,8 @@ router.post('/logs', auditWriteLimiter, requirePermission('audit.write'), async 
         JSON.stringify(parsedDetails),
         req.ip || null,
         req.headers['user-agent'] || null,
-        outcome || 'success',
+        resolvedOutcome === 'success',
+        resolvedOutcome,
         source_system || 'mcp_agent'
       ]
     );

--- a/backend/src/services/auditService.js
+++ b/backend/src/services/auditService.js
@@ -351,12 +351,19 @@ async function analyzeIntegrationData(organizationId, integrationData, sourceSys
  * Extract common audit context from Express request
  */
 function extractAuditContext(req) {
+  // sessionId and authenticationMethod are deliberately not derived here.
+  // Neither is available on a request: the JWT payload carries only userId,
+  // the authenticate middleware's user projection selects no such columns,
+  // and express-session is not a dependency -- so the previous reads of
+  // req.user.session_id, req.sessionID and req.user.authentication_method
+  // always evaluated to undefined. Keeping them made every request-derived
+  // record appear to carry session context it could never have had.
+  // Authentication events still set authentication_method, by passing
+  // authMethod explicitly through logAuthentication().
   return {
     ipAddress: req.ip || req.headers['x-forwarded-for'] || req.socket?.remoteAddress,
     userAgent: req.headers['user-agent'],
-    requestId: req.requestId,
-    sessionId: req.user?.session_id || req.sessionID,
-    authenticationMethod: req.user?.authentication_method
+    requestId: req.requestId
   };
 }
 
@@ -391,8 +398,8 @@ async function logFromRequest(req, params) {
     ipAddress: params.ipAddress || context.ipAddress,
     userAgent: params.userAgent || context.userAgent,
     requestId: params.requestId || context.requestId,
-    sessionId: params.sessionId || context.sessionId,
-    authenticationMethod: params.authenticationMethod || context.authenticationMethod,
+    sessionId: params.sessionId,
+    authenticationMethod: params.authenticationMethod,
     actorName: params.actorName || actorName
   });
 }

--- a/docs/FEDRAMP_DEPLOYMENT_GUIDE.md
+++ b/docs/FEDRAMP_DEPLOYMENT_GUIDE.md
@@ -73,12 +73,17 @@ All secrets must be injected via environment variables — never hardcoded in so
 | Variable | Recommended Value | Notes |
 |----------|-------------------|-------|
 | `DB_SSL_MODE` | `require` | Enforces TLS on all DB connections |
-| `AUDIT_LOG_RETENTION_DAYS` | `1095` | 3 years per NIST AU-11 for High |
 | `SESSION_TIMEOUT_MINUTES` | `30` | Satisfies FRH-AC-12 session termination |
 | `MFA_REQUIRED` | `true` | Required for all admin accounts under FRH-IA-5(2) |
 | `NODE_ENV` | `production` | Disables stack traces in error responses |
 | `RATE_LIMIT_WINDOW_MS` | `900000` | 15-minute window |
 | `RATE_LIMIT_MAX` | `100` | Requests per window per IP |
+
+> **AU-11 retention is not configurable through the application.** An
+> `AUDIT_LOG_RETENTION_DAYS` variable was previously listed here; no such
+> variable is read anywhere in the codebase and setting it has no effect.
+> Audit-record retention must be enforced outside the platform — see the
+> AU-11 row in section 5.
 
 ---
 
@@ -141,13 +146,13 @@ do not claim them on the strength of this table.
 | NIST Control | Status | Implementation |
 |-------------|--------|----------------|
 | AU-2 | Partial | Events are recorded to `audit_logs.event_type`. Most routes write through `services/auditService.js`, but a number of route handlers issue their own `INSERT INTO audit_logs` with a narrower column set, so field coverage is not uniform across event types. `event_type` is free-text — there is no enforced event registry. |
-| AU-3 | Partial | Recorded per event: `event_type`, `created_at`, `user_id`, `actor_name`, `organization_id`, `resource_type`, `resource_id`, `ip_address`, `user_agent`, `success`, `outcome`, `failure_reason`, `request_id`, `source_system`. **Not recorded as columns:** HTTP method and request path (captured only inside the `details` JSONB by `middleware/auditLog.js`), and before/after values. The `session_id` and `authentication_method` columns exist but are populated only by the authentication events in `auditService.logAuthentication`, not by request-derived logging. |
+| AU-3 | Partial | Recorded per event: `event_type`, `created_at`, `user_id`, `actor_name`, `organization_id`, `resource_type`, `resource_id`, `ip_address`, `user_agent`, `success`, `outcome`, `failure_reason`, `request_id`, `source_system`. **Not recorded as columns:** HTTP method and request path (captured only inside the `details` JSONB by `middleware/auditLog.js`), and before/after values. `authentication_method` is populated for authentication events only (set explicitly by `auditService.logAuthentication`/`logLogout`); `session_id` has no writer at all — the platform issues stateless JWTs carrying no session identifier, so use `request_id` for per-request correlation. Both columns are documented as such in the schema. |
 | AU-4 | **Deployer-supplied** | No audit-log storage-capacity monitoring or alerting exists. Monitor table growth and provision storage externally. |
 | AU-5 | **Deployer-supplied** | No response to audit-logging failures. A failed audit write is written to the process stdout/stderr stream and the originating request still succeeds; these writes do not reach the structured logger or Sentry. Alerting on audit-pipeline failure must be supplied externally. |
 | AU-6 | Implemented | `GET /api/v1/audit/logs` with filtering by user, event type, resource, and date range; `GET /api/v1/audit/stats`; dashboard audit trail at `/dashboard/audit`. Optional SIEM forwarding via `services/siemService.js`. |
 | AU-7 | Partial | Filtering and event-type aggregation are available through the endpoints above. There is no audit-record export endpoint — auditors must pull through the API or the database. |
-| AU-8 | Partial | `audit_logs.created_at` is `TIMESTAMP` **without** time zone, set server-side by `NOW()`. Deploy the database in UTC so recorded times are unambiguous. Time synchronization (NTP) is deployer-supplied. |
-| AU-9 | **Partial — weak** | Row-level security (`FORCE`, migration `105`) provides tenant isolation only; its policy is `USING`-only and therefore does not restrict writes. There is **no append-only enforcement on `audit_logs`** in this repository — no trigger, no `REVOKE`, and no hash chain — so records are modifiable and deletable by any code path holding the application's database role. Additionally, `organization_id` is `ON DELETE CASCADE`, so deleting an organization destroys its audit history. FRH-AU-9(3) requires cryptographic integrity: supplement with write-once log shipping, and treat an external immutable copy as required rather than optional. |
+| AU-8 | Implemented | `audit_logs.created_at` is `timestamptz` (migration 152), set server-side by `NOW()` and never supplied by the caller, so every record is unambiguously mappable to UTC. Time synchronization (NTP) on the database host remains deployer-supplied. |
+| AU-9 | Partial | Append-only is enforced in the database by the triggers in migration `153`: `DELETE` and `TRUNCATE` are rejected, and `UPDATE` is rejected for every column except `siem_forwarded`. Row-level security (`FORCE`, migration `105`) provides tenant isolation. This is tamper-**resistant**, not tamper-**evident** — there is no hash chain or record signature, and the application owns the table, so a privileged code path can disable the trigger. Note also that `organization_id` is `ON DELETE CASCADE`, so deleting an organization still removes its audit history. FRH-AU-9(3) requires cryptographic integrity: supplement with write-once log shipping. |
 | AU-10 | Partial | `user_id`, `actor_name`, and `ip_address` are recorded on records written through `auditService`. Note `user_id` is `ON DELETE SET NULL`, so deleting a user detaches the identity from historical records (`actor_name` is retained). No digital signature is applied; FRH-AU-10 requires one — supplement with an external signing service. |
 | AU-11 | **Deployer-supplied** | No retention period is enforced for `audit_logs`. The `data_retention_policies` table lists `audit_logs` as an intended `resource_type`, but the retention scheduler acts on evidence only. Records accumulate indefinitely. |
 | AU-12 | Partial | Audit records are generated by route handlers calling `auditService`. The `middleware/auditLog.js` wrapper — the only path that records HTTP method and path — is mounted on a single router (`routes/dataSovereignty.js`) and fires only on 2xx responses, so it does not record failed operations. |


### PR DESCRIPTION
## Description

Second PR of the AU control family remediation. #268 corrected the false claims; this one makes the most important of them true.

> **Stacked on #268.** Base is `claude/au-control-family-audit-01iojz-au-docs`, not `main`, so the diff shows only this PR's changes. GitHub will retarget to `main` automatically when #268 merges.

The headline is **AU-9**: this repository had *no* protection of audit records. `README.md` and `PROJECT_STATUS.md` called the audit log "immutable", but the only thing standing between a record and a rewrite was that `routes/audit.js` happens not to expose an UPDATE or DELETE route. That is convention, not a control.

## Type of Change

- [x] 🔒 Security fix
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] 🎨 Code style / refactor (no functional changes)
- [ ] 🧪 Tests
- [ ] 🔧 CI/CD / tooling

## Changes Made

**Migration 153 — append-only enforcement (AU-9).** A verbatim port of the sibling ControlWeaver-Pro repo's migration 121: a trigger rejects `DELETE` and `TRUNCATE` outright, and rejects `UPDATE` for every column except `siem_forwarded`. Logic kept identical so the two repos do not drift on an audit control. A trigger rather than `REVOKE` because these deployments run the app under one owning role, and `REVOKE` does not constrain the object owner.

Compatibility was checked before adding it, and the result differs from the sibling repo in a way worth recording: the only post-insert write anywhere here is `auditService.js:146` setting `siem_forwarded` (which the trigger permits), and **no seed or reset script issues `DELETE FROM audit_logs`** — so unlike ControlWeaver-Pro, nothing needed a trigger-disable wrapper. The migration header records that finding and the requirement for any future script.

**Migration 152 — `created_at` to `timestamptz` (AU-8).** It was `TIMESTAMP WITHOUT TIME ZONE` defaulted by `NOW()`, so the instant was only interpretable if the reader independently knew the server's zone. Runs before 153 so the type change happens while the table is still freely rewritable.

**`POST /audit/logs` outcome integrity.** The handler hardcoded `success = true` while accepting a caller-supplied `outcome`, so a client could write a record asserting `success = true` alongside `outcome = 'failure'` — a self-contradicting entry from the endpoint whose purpose is producing trustworthy ones. `success` is now derived from `outcome`; `outcome` is validated against the values documented in migration 048. A malformed `resource_id` (a UUID column) now returns 400 rather than an opaque 500.

**Dead session context removed.** `auditService.extractAuditContext` read `req.user.session_id`, `req.sessionID` and `req.user.authentication_method`. None exist — the JWT payload carries only `userId`, the authenticate middleware's projection selects neither column, and `express-session` is not a dependency. All three always evaluated to `undefined` while making request-derived records look like they carried session context. Same dead read removed from `middleware/auditLog.js`. Both columns are retained and now documented in the schema: `authentication_method` is genuinely set by authentication events, `session_id` is marked reserved with `request_id` named as the correlation field.

**Doc rows updated:** AU-8 Partial → Implemented; AU-9 "Partial — weak" → Partial (still noting `ON DELETE CASCADE` on `organization_id`); AU-3 now says `session_id` has no writer.

## Testing

- [x] Ran database migrations — `npm run check:syntax` passes (265 files)
- [x] Checked that existing functionality is not broken — verified the only existing `UPDATE audit_logs` in the repo is the `siem_forwarded` write the trigger permits
- [ ] Tested backend endpoints manually — not run in this environment, see caveat below

```bash
cd backend && npm run check:syntax   # Syntax check passed for 265 files.
grep -rn "UPDATE audit_logs" backend/src backend/scripts   # only auditService.js:146 (siem_forwarded)
grep -rniE "delete[[:space:]]+from[[:space:]]+audit_logs" backend/ --include=*.js   # no matches
```

**Test caveat, stated plainly:** `npx jest` fails in my environment with `Cannot find module '@babel/preset-env'` for all 19 suites, including files this PR does not touch — devDependencies are not installed here, so `npx` fetches its own jest. That is environmental, not a result of this diff, but it does mean **I have not seen the unit suite pass**. CI runs it with dependencies installed.

**Not executed against a live database.** The trigger and the type conversion need verification on a real instance:

```sql
-- must both raise insufficient_privilege
UPDATE audit_logs SET event_type = 'x' WHERE id = (SELECT id FROM audit_logs LIMIT 1);
DELETE FROM audit_logs WHERE id = (SELECT id FROM audit_logs LIMIT 1);
-- must still succeed
UPDATE audit_logs SET siem_forwarded = TRUE WHERE id = (SELECT id FROM audit_logs LIMIT 1);
-- confirm the type conversion preserved values
SHOW timezone;  -- must be UTC before applying 152, see the migration header
SELECT created_at FROM audit_logs ORDER BY created_at LIMIT 5;
```

## Checklist

- [x] My branch follows the naming convention
- [x] My code follows the existing code style
- [x] I've added comments for complex logic
- [x] I've updated documentation if needed
- [x] I've checked for SQL injection / security issues in any database queries — the new validation is an allow-list plus a regex; all queries stay parameterized
- [x] I've not introduced any hardcoded secrets or API keys
- [x] This PR is focused
- [ ] I've updated `RELEASE_NOTES.md` — the repo's release-notes automation generates the entry on merge

## Additional Notes

**Scope boundary.** This makes the table tamper-*resistant*, not tamper-*evident*. The application owns the table and can still `DISABLE TRIGGER`; detecting a mutation that got through requires a hash chain, which is a later PR in this series along with the `ON DELETE CASCADE` on `organization_id`.

**One correction to #268.** That PR removed the fictional `AUDIT_LOG_RETENTION_DAYS` from the AU table but missed the same variable in the recommended-environment-variables table in section 3, which was still instructing operators to set `AUDIT_LOG_RETENTION_DAYS=1095`. Fixed here and replaced with a note that AU-11 retention is not configurable through the application.

**Still deferred:** AU-4, AU-5, AU-7 and AU-11 remain deployer-supplied after this PR, and AU-3 field coverage is still uneven across the ~40 direct `INSERT INTO audit_logs` call sites. Those are the next two PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkY9DTQSdAX1NV4Se9KWpE)_