### PR TITLE
feat(audit): implement AU-5 failure response, AU-7 export, AU-11 retention

### DIFF
--- a/backend/src/middleware/auditLog.js
+++ b/backend/src/middleware/auditLog.js
@@ -9,6 +9,7 @@
  */
 
 const { createAuditLog } = require('../services/auditService');
+const { log, serializeError } = require('../utils/logger');
 const { extractIpFromRequest } = require('../services/geolocationService');
 
 /**
@@ -71,12 +72,15 @@ function auditLog(eventType, options = {}) {
           requestId: req.requestId || null,
           actorName: user.username || user.email || null
         }).catch(err => {
-          // Log error but don't fail the request
-          console.error('Failed to create audit log:', err);
+          // AU-5: the request still succeeds, but this event never made it
+          // into the audit trail -- do not let that pass unreported.
+          log('error', 'audit.write_failed',
+            { eventType, path: req.path, method: req.method, error: serializeError(err) });
         });
       } catch (error) {
-        // Silently fail - audit logging should not break the application
-        console.error('Audit log middleware error:', error);
+        // Do not break the request, but do not fail silently either.
+        log('error', 'audit.middleware_failed',
+          { eventType, path: req.path, method: req.method, error: serializeError(error) });
       }
     };
     

--- a/backend/src/routes/audit.js
+++ b/backend/src/routes/audit.js
@@ -9,6 +9,8 @@ const dynamicFieldsService = require('../services/dynamicAuditFieldsService');
 const { createRateLimiter } = require('../middleware/rateLimit');
 const { decodeCursor, nextCursorFrom } = require('../utils/keysetPagination');
 const rateLimit = require('express-rate-limit');
+const auditService = require('../services/auditService');
+const { log, serializeError } = require('../utils/logger');
 
 const auditWriteLimiter = createRateLimiter({
   label: 'audit-log-write',
@@ -36,6 +38,48 @@ const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3
 router.use(rateLimit({ windowMs: 15 * 60 * 1000, max: 300 }));
 
 router.use(authenticate);
+
+// Shared filter builder for the audit read paths. GET /logs and GET /export
+// must agree on what a given filter set selects -- an export that quietly
+// returns a different population than the screen the auditor was looking at
+// is worse than no export. Appends to `params` and returns the next
+// placeholder index; every value is parameterized.
+function buildAuditFilterClause(query, params, startIdx) {
+  const { userId, eventType, resourceType, resourceId, startDate, endDate,
+    findingKey, vulnerabilityId, source, outcome } = query;
+  let clause = '';
+  let idx = startIdx;
+  const add = (sql, value) => {
+    clause += ` AND ${sql.replace('$$', `$${idx}`)}`;
+    params.push(value);
+    idx++;
+  };
+
+  if (userId) add('al.user_id = $$', userId);
+  if (eventType) add('al.event_type = $$', eventType);
+  if (resourceType) add('al.resource_type = $$', String(resourceType));
+  if (resourceId) add('al.resource_id::text = $$', String(resourceId));
+  if (startDate) add('al.created_at >= $$', startDate);
+  if (endDate) add('al.created_at <= $$', endDate);
+  if (findingKey) add("al.details->>'finding_key' = $$", String(findingKey));
+  if (vulnerabilityId) add("al.details->>'vulnerability_id' = $$", String(vulnerabilityId));
+  if (source) add("al.details->>'source' = $$", String(source));
+  // Not offered by GET /logs before this change: an assessor reviewing AU-6
+  // findings almost always wants the failures on their own.
+  if (outcome) add('al.outcome = $$', String(outcome));
+
+  return { clause, nextIdx: idx };
+}
+
+// RFC 4180 escaping. A leading =, +, - or @ is prefixed with a single quote so
+// spreadsheet software does not evaluate an audit value as a formula.
+function csvCell(value) {
+  if (value === null || value === undefined) return '';
+  let s = typeof value === 'object' ? JSON.stringify(value) : String(value);
+  if (/^[=+\-@]/.test(s)) s = `'${s}`;
+  if (/[",\r\n]/.test(s)) s = `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
 
 // GET /audit/logs
 router.get('/logs', requirePermission('audit.read'), async (req, res) => {
@@ -77,51 +121,9 @@ router.get('/logs', requirePermission('audit.read'), async (req, res) => {
     const params = [orgId];
     let idx = 2;
 
-    if (userId) {
-      query += ` AND al.user_id = $${idx}`;
-      params.push(userId);
-      idx++;
-    }
-    if (eventType) {
-      query += ` AND al.event_type = $${idx}`;
-      params.push(eventType);
-      idx++;
-    }
-    if (resourceType) {
-      query += ` AND al.resource_type = $${idx}`;
-      params.push(String(resourceType));
-      idx++;
-    }
-    if (resourceId) {
-      query += ` AND al.resource_id::text = $${idx}`;
-      params.push(String(resourceId));
-      idx++;
-    }
-    if (startDate) {
-      query += ` AND al.created_at >= $${idx}`;
-      params.push(startDate);
-      idx++;
-    }
-    if (endDate) {
-      query += ` AND al.created_at <= $${idx}`;
-      params.push(endDate);
-      idx++;
-    }
-    if (findingKey) {
-      query += ` AND al.details->>'finding_key' = $${idx}`;
-      params.push(String(findingKey));
-      idx++;
-    }
-    if (vulnerabilityId) {
-      query += ` AND al.details->>'vulnerability_id' = $${idx}`;
-      params.push(String(vulnerabilityId));
-      idx++;
-    }
-    if (source) {
-      query += ` AND al.details->>'source' = $${idx}`;
-      params.push(String(source));
-      idx++;
-    }
+    const filters = buildAuditFilterClause(req.query, params, idx);
+    query += filters.clause;
+    idx = filters.nextIdx;
 
     if (keyset) {
       query += ` AND (al.created_at, al.id) < ($${idx}, $${idx + 1})`;
@@ -291,6 +293,112 @@ router.post('/logs', auditWriteLimiter, requirePermission('audit.write'), async 
   } catch (error) {
     console.error('Audit log create error:', error);
     res.status(500).json({ success: false, error: 'Failed to create audit log entry' });
+  }
+});
+
+// GET /audit/export — AU-7 (Audit Record Reduction and Report Generation)
+//
+// Auditors previously had no way to take audit records out of the platform;
+// the only options were paging the API by hand or going to the database.
+// Accepts the same filters as GET /logs and streams the result so a
+// multi-year export does not have to be held in memory. Rows are written in
+// keyset batches rather than one unbounded query for the same reason.
+router.get('/export', requirePermission('audit.read'), async (req, res) => {
+  const format = String(req.query.format || 'csv').toLowerCase();
+  if (!['csv', 'json'].includes(format)) {
+    return res.status(400).json({ success: false, error: "format must be 'csv' or 'json'." });
+  }
+
+  const COLUMNS = [
+    'id', 'created_at', 'event_type', 'outcome', 'success', 'failure_reason',
+    'actor_name', 'user_email', 'user_id', 'organization_id',
+    'resource_type', 'resource_id', 'ip_address', 'user_agent',
+    'request_id', 'source_system', 'authentication_method', 'sso_provider',
+    'siem_forwarded', 'details'
+  ];
+  const BATCH = 1000;
+
+  try {
+    const orgId = req.user.organization_id;
+    const stamp = new Date().toISOString().slice(0, 10);
+    res.setHeader('Content-Type', format === 'csv' ? 'text/csv; charset=utf-8' : 'application/json');
+    res.setHeader('Content-Disposition', `attachment; filename="audit-log-${stamp}.${format}"`);
+
+    if (format === 'csv') {
+      res.write(COLUMNS.join(',') + '\n');
+    } else {
+      res.write('[');
+    }
+
+    let lastCreatedAt = null;
+    let lastId = null;
+    let wrote = 0;
+
+    for (;;) {
+      const params = [orgId];
+      let idx = 2;
+      let sql = `
+        SELECT al.id, al.created_at, al.event_type, al.outcome, al.success,
+               al.failure_reason, al.actor_name, al.user_id, al.organization_id,
+               al.resource_type, al.resource_id, al.ip_address, al.user_agent,
+               al.request_id, al.source_system, al.authentication_method,
+               al.sso_provider, al.siem_forwarded, al.details,
+               u.email as user_email
+        FROM audit_logs al
+        LEFT JOIN users u ON u.id = al.user_id
+        WHERE al.organization_id = $1
+      `;
+      const filters = buildAuditFilterClause(req.query, params, idx);
+      sql += filters.clause;
+      idx = filters.nextIdx;
+
+      if (lastCreatedAt !== null) {
+        sql += ` AND (al.created_at, al.id) > ($${idx}, $${idx + 1})`;
+        params.push(lastCreatedAt, lastId);
+        idx += 2;
+      }
+
+      sql += ` ORDER BY al.created_at ASC, al.id ASC LIMIT ${BATCH}`;
+
+      const { rows } = await pool.query(sql, params);
+      if (rows.length === 0) break;
+
+      for (const row of rows) {
+        // Stored encrypted; decrypt for the export the same way GET /logs does.
+        row.user_email = row.user_email ? decrypt(row.user_email) : null;
+        if (format === 'csv') {
+          res.write(COLUMNS.map((c) => csvCell(row[c])).join(',') + '\n');
+        } else {
+          res.write((wrote === 0 ? '' : ',') + JSON.stringify(row));
+        }
+        wrote++;
+      }
+
+      lastCreatedAt = rows[rows.length - 1].created_at;
+      lastId = rows[rows.length - 1].id;
+      if (rows.length < BATCH) break;
+    }
+
+    if (format === 'json') res.write(']');
+    res.end();
+
+    // The export itself is an auditable read of the audit trail (AU-6/AU-9).
+    auditService.logFromRequest(req, {
+      eventType: 'audit.exported',
+      resourceType: 'audit_log',
+      details: { format, row_count: wrote, filters: req.query }
+    }).catch((err) => log('error', 'audit.write_failed',
+      { eventType: 'audit.exported', error: serializeError(err) }));
+  } catch (error) {
+    log('error', 'audit.export_failed', { error: serializeError(error) });
+    // Headers are already sent once streaming has begun, so the only honest
+    // signal left is to break the stream rather than end it cleanly and hand
+    // the auditor a silently truncated file.
+    if (res.headersSent) {
+      res.destroy(error);
+      return;
+    }
+    res.status(500).json({ success: false, error: 'Failed to export audit log' });
   }
 });
 

--- a/backend/src/routes/ops.js
+++ b/backend/src/routes/ops.js
@@ -5,6 +5,7 @@ const pool = require('../config/database');
 const { authenticate, requirePermission } = require('../middleware/auth');
 const { enqueueJob, processPendingJobs, runRetentionCleanup } = require('../services/jobService');
 const { processPendingWebhookDeliveries } = require('../services/webhookService');
+const { getAuditFailureStats } = require('../services/auditService');
 
 router.use(authenticate);
 router.use(requirePermission('settings.manage'));
@@ -146,12 +147,15 @@ router.get('/overview', async (req, res) => {
       webhooksByStatus[row.delivery_status] = Number(row.count || 0);
     }
 
+    const auditPipeline = getAuditFailureStats();
+
     const openIssueCount =
       Number(activity.failures_24h || 0)
       + Number(findings.open_vulnerabilities || 0)
       + Number(poam.active_poam_items || 0)
       + Number(jobsByStatus.failed || 0)
-      + Number(webhooksByStatus.failed || 0);
+      + Number(webhooksByStatus.failed || 0)
+      + Number(auditPipeline.writeFailures || 0);
 
     res.json({
       success: true,
@@ -168,6 +172,12 @@ router.get('/overview', async (req, res) => {
         },
         jobs: jobsByStatus,
         webhooks: webhooksByStatus,
+        // AU-5: distinct from summary.failures_24h, which counts audited
+        // business events that failed. These count failures of the audit
+        // pipeline itself -- writes that never reached the table, and records
+        // that never reached the SIEM. A non-zero value here means the trail
+        // is incomplete, which failures_24h can never tell you.
+        audit_pipeline: auditPipeline,
         top_events_7d: topEventsResult.rows.map((row) => ({
           event_type: row.event_type,
           count: Number(row.count || 0)

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -44,6 +44,8 @@ const _reminderMod = safeRequire('./services/reminderService');
 const startReminderScheduler = _reminderMod ? _reminderMod.startReminderScheduler : null;
 const _reportSchedulerMod = safeRequire('./services/reportScheduler');
 const startReportScheduler = _reportSchedulerMod ? _reportSchedulerMod.startReportScheduler : null;
+const _retentionSchedulerMod = safeRequire('./services/retentionScheduler');
+const startRetentionScheduler = _retentionSchedulerMod ? _retentionSchedulerMod.startRetentionScheduler : null;
 const { SECURITY_CONFIG } = require('./config/security');
 const { validateEdition, getEditionInfo, attachEditionInfo } = require('./middleware/edition');
 const { getRedisAdapterStatus } = require('./services/websocketService');
@@ -865,6 +867,7 @@ async function ensureLicenseFromDb() {
 // procedures) are intentionally deferred until after the server is listening.
 let stopReminders = () => {};
 let stopReportScheduler = () => {};
+let stopRetentionScheduler = () => {};
 const HOST = process.env.HOST || '0.0.0.0';
 
 ensureLicenseFromDb()
@@ -890,6 +893,7 @@ ensureLicenseFromDb()
       if (databaseConfigured) {
         stopReminders = startReminderScheduler ? startReminderScheduler() : () => {};
         stopReportScheduler = startReportScheduler ? startReportScheduler() : () => {};
+        stopRetentionScheduler = startRetentionScheduler ? startRetentionScheduler() : () => {};
 
         // Start scheduled database backups if enabled.
         // In PM2 cluster mode pm_id is set per-worker (0-indexed); only worker 0
@@ -925,6 +929,7 @@ ensureLicenseFromDb()
       log('warn', 'server.shutdown.requested', { signal });
       stopReminders();
       stopReportScheduler();
+      stopRetentionScheduler();
       const _bs = safeRequire('./services/backupScheduler');
       if (_bs) _bs.stop();
       server.close(() => {

--- a/backend/src/services/auditService.js
+++ b/backend/src/services/auditService.js
@@ -15,6 +15,44 @@
 const pool = require('../config/database');
 const siemService = require('./siemService');
 const dynamicFieldsService = require('./dynamicAuditFieldsService');
+const { log, serializeError } = require('../utils/logger');
+
+/**
+ * AU-5 (Response to Audit Logging Process Failures).
+ *
+ * An audit pipeline that fails silently is indistinguishable from one that is
+ * idle, which is the failure mode AU-5 exists to prevent. Every failure below
+ * is therefore routed through the structured logger -- reaching Sentry, unlike
+ * the bare console.error calls these replaced -- and counted here so the
+ * operations dashboard can surface a broken pipeline without waiting for
+ * someone to notice missing events.
+ *
+ * The counter is per-process and resets on restart. It is a liveness signal
+ * for the running instance, not a durable metric; the logged events are the
+ * durable record.
+ */
+const auditFailureStats = {
+  writeFailures: 0,
+  siemFailures: 0,
+  lastWriteFailureAt: null,
+  lastSiemFailureAt: null
+};
+
+function recordAuditFailure(kind, event, error, context = {}) {
+  const now = new Date().toISOString();
+  if (kind === 'siem') {
+    auditFailureStats.siemFailures += 1;
+    auditFailureStats.lastSiemFailureAt = now;
+  } else {
+    auditFailureStats.writeFailures += 1;
+    auditFailureStats.lastWriteFailureAt = now;
+  }
+  log('error', event, { ...context, error: serializeError(error) });
+}
+
+function getAuditFailureStats() {
+  return { ...auditFailureStats };
+}
 
 /**
  * Create an audit log entry with AU-2 compliant fields
@@ -91,7 +129,8 @@ async function createAuditLog(params) {
     // Analyze integration data for AI suggestions if provided
     if (integrationData && sourceSystem) {
       analyzeIntegrationData(organizationId, integrationData, sourceSystem).catch(err => {
-        console.error('Integration data analysis error:', err);
+        log('error', 'audit.integration_analysis_failed',
+          { organizationId, sourceSystem, error: serializeError(err) });
       });
     }
 
@@ -117,14 +156,21 @@ async function createAuditLog(params) {
       timestamp: new Date().toISOString(),
       custom_fields: customFields
     }).catch(err => {
-      // Log SIEM forwarding errors but don't fail the audit log creation
-      console.error('SIEM forwarding error:', err);
+      // AU-5: the record is in the local table but did not reach the SIEM, so
+      // any external correlation is now incomplete. Surface it.
+      recordAuditFailure('siem', 'audit.siem_forward_failed', err,
+        { organizationId, eventType, auditLogId });
     });
 
     return auditLogId;
   } catch (error) {
-    // Audit logging failures should be logged but not block operations
-    console.error('Audit log creation error:', error);
+    // AU-5: the write failed, so this event is not in the audit trail. Record
+    // it where an operator will actually see it before rethrowing.
+    recordAuditFailure('write', 'audit.write_failed', error, {
+      eventType,
+      organizationId,
+      resourceType
+    });
     throw error;
   }
 }
@@ -150,7 +196,7 @@ async function forwardToSiem(organizationId, auditLogId, eventType, payload) {
 
     return results;
   } catch (error) {
-    console.error('SIEM forwarding failed:', error);
+    recordAuditFailure('siem', 'audit.siem_forward_failed', error, { organizationId });
     return [];
   }
 }
@@ -326,7 +372,8 @@ async function storeCustomFields(auditLogId, organizationId, customFields, sourc
       }
     }
   } catch (error) {
-    console.error('Error storing custom fields:', error);
+    log('error', 'audit.custom_fields_store_failed',
+      { auditLogId, organizationId, error: serializeError(error) });
     // Don't throw - custom field storage shouldn't break audit logging
   }
 }
@@ -342,7 +389,8 @@ async function analyzeIntegrationData(organizationId, integrationData, sourceSys
       sourceSystem
     );
   } catch (error) {
-    console.error(`Error analyzing integration data for org ${organizationId}, source ${sourceSystem}:`, error);
+    log('error', 'audit.integration_analysis_failed',
+      { organizationId, sourceSystem, error: serializeError(error) });
     // Don't throw - this is a non-critical background operation
   }
 }
@@ -415,5 +463,6 @@ module.exports = {
   extractAuditContext,
   getActorName,
   storeCustomFields,
-  analyzeIntegrationData
+  analyzeIntegrationData,
+  getAuditFailureStats
 };

--- a/backend/src/services/jobService.js
+++ b/backend/src/services/jobService.js
@@ -6,7 +6,7 @@ const pool = require('../config/database');
 const { processPendingWebhookDeliveries } = require('./webhookService');
 const { generateReportFile } = require('./scheduledReportService');
 const { sendReportEmail } = require('./emailService');
-const { log } = require('../utils/logger');
+const { log, serializeError } = require('../utils/logger');
 
 const SCHEDULE_INTERVAL_MS = Object.freeze({
   daily: 24 * 60 * 60 * 1000,
@@ -96,6 +96,138 @@ async function runRetentionCleanup({ organizationId }) {
   return { removed, skipped, policy_days: strictestDays };
 }
 
+// AU-11 (Audit Record Retention).
+//
+// Audit records previously had no retention path at all: data_retention_policies
+// names 'audit_logs' as an intended resource_type, but enforcement only ever
+// looked at evidence, so records accumulated indefinitely. Two properties make
+// deleting audit records different from deleting evidence, and both are
+// enforced here rather than left to the caller.
+//
+// 1. A floor. Retention that can be set arbitrarily low is an attacker's
+//    delete button: set the policy to one day, wait, and the trail is gone
+//    within policy. AUDIT_LOG_MIN_RETENTION_DAYS raises the floor for a
+//    deployment (FedRAMP High wants 1095), and AUDIT_RETENTION_ABSOLUTE_FLOOR
+//    is the value no policy or environment variable can go below.
+//
+// 2. The append-only trigger. Purging necessarily disables the protection
+//    added for AU-9, which is the one moment the table is writable. The window
+//    is therefore held inside a single transaction -- so a failure rolls the
+//    trigger back on -- kept as narrow as possible, and the purge itself is
+//    written to the audit trail so the deletion is visible in the record it
+//    modified.
+//
+// Legal holds are honored: a hold covering audit_logs suspends the purge
+// entirely rather than deleting around it, because a partial purge under hold
+// is harder to explain to an assessor than none at all.
+const AUDIT_RETENTION_ABSOLUTE_FLOOR_DAYS = 90;
+
+async function runAuditLogRetention({ organizationId }) {
+  const configuredFloor = Number(process.env.AUDIT_LOG_MIN_RETENTION_DAYS || 365);
+  const floorDays = Math.max(
+    AUDIT_RETENTION_ABSOLUTE_FLOOR_DAYS,
+    Number.isFinite(configuredFloor) ? configuredFloor : 365
+  );
+
+  const policyResult = await pool.query(
+    `SELECT id, retention_days
+       FROM data_retention_policies
+      WHERE organization_id = $1
+        AND active = true
+        AND auto_enforce = true
+        AND resource_type = 'audit_logs'
+      ORDER BY retention_days ASC`,
+    [organizationId]
+  );
+
+  if (policyResult.rows.length === 0) {
+    return { removed: 0, reason: 'No active audit_logs retention policy.' };
+  }
+
+  const holdResult = await pool.query(
+    `SELECT 1
+       FROM legal_holds
+      WHERE organization_id = $1
+        AND active = true
+        AND resource_type = 'audit_logs'
+      LIMIT 1`,
+    [organizationId]
+  );
+  if (holdResult.rows.length > 0) {
+    return { removed: 0, reason: 'Legal hold active on audit_logs; purge suspended.' };
+  }
+
+  const requestedDays = Math.min(...policyResult.rows.map((p) => Number(p.retention_days || floorDays)));
+  const effectiveDays = Math.max(floorDays, requestedDays);
+  const floorApplied = effectiveDays !== requestedDays;
+
+  const client = await pool.connect();
+  let removed = 0;
+  try {
+    await client.query('BEGIN');
+
+    const { rows: [{ count }] } = await client.query(
+      `SELECT COUNT(*)::int AS count
+         FROM audit_logs
+        WHERE organization_id = $1
+          AND created_at < NOW() - ($2 || ' days')::interval`,
+      [organizationId, String(effectiveDays)]
+    );
+
+    if (count > 0) {
+      // The narrowest possible window in which audit_logs is writable.
+      await client.query('ALTER TABLE audit_logs DISABLE TRIGGER audit_logs_no_update');
+      try {
+        const del = await client.query(
+          `DELETE FROM audit_logs
+            WHERE organization_id = $1
+              AND created_at < NOW() - ($2 || ' days')::interval`,
+          [organizationId, String(effectiveDays)]
+        );
+        removed = del.rowCount || 0;
+      } finally {
+        await client.query('ALTER TABLE audit_logs ENABLE TRIGGER audit_logs_no_update');
+      }
+
+      // Record the purge in the trail it just modified. Inside the same
+      // transaction, so a rollback discards the claim along with the deletion.
+      await client.query(
+        `INSERT INTO audit_logs
+           (organization_id, event_type, resource_type, details, success, outcome, source_system, created_at)
+         VALUES ($1, 'audit.retention_purge', 'audit_log', $2::jsonb, true, 'success', 'retention-job', NOW())`,
+        [organizationId, JSON.stringify({
+          removed,
+          effective_retention_days: effectiveDays,
+          requested_retention_days: requestedDays,
+          floor_days: floorDays,
+          floor_applied: floorApplied,
+          policy_ids: policyResult.rows.map((p) => p.id)
+        })]
+      );
+    }
+
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    log('error', 'audit.retention_purge_failed',
+      { organizationId, effectiveDays, error: serializeError(error) });
+    throw error;
+  } finally {
+    client.release();
+  }
+
+  if (floorApplied) {
+    log('warn', 'audit.retention_floor_applied', {
+      organizationId,
+      requestedDays,
+      effectiveDays,
+      floorDays
+    });
+  }
+
+  return { removed, effective_retention_days: effectiveDays, floor_applied: floorApplied };
+}
+
 async function runJob(jobRow) {
   const payload = jobRow.payload || {};
   switch (jobRow.job_type) {
@@ -109,6 +241,11 @@ async function runJob(jobRow) {
         return { removed: 0, skipped: 0, reason: 'No organization_id on job.' };
       }
       return runRetentionCleanup({ organizationId: jobRow.organization_id });
+    case 'audit_log_retention':
+      if (!jobRow.organization_id) {
+        return { removed: 0, reason: 'No organization_id on job.' };
+      }
+      return runAuditLogRetention({ organizationId: jobRow.organization_id });
     case 'integration_sync':
       return { synced: true, connector_id: payload.connectorId || null, mode: payload.mode || 'manual' };
     case 'evidence_auto_collect':
@@ -455,5 +592,6 @@ module.exports = {
   enqueueJob,
   processPendingJobs,
   runRetentionCleanup,
+  runAuditLogRetention,
   runScheduledReport
 };

--- a/backend/src/services/retentionScheduler.js
+++ b/backend/src/services/retentionScheduler.js
@@ -1,0 +1,117 @@
+// @tier: community
+// Periodic sweep that actually runs retention enforcement.
+//
+// Ported from the sibling ControlWeaver-Pro repository, where this sweep has
+// been running for some time. Without it, jobService.runRetentionCleanup() and
+// runAuditLogRetention() exist and are correct, but nothing ever invokes them:
+// the 'retention_cleanup' and 'audit_log_retention' job types only run if an
+// operator enqueues them by hand. That made evidence retention -- and, once
+// AU-11 landed, audit retention -- a capability rather than an enforced
+// control. Modeled on services/reminderService.js's setInterval sweep pattern.
+//
+// Evidence and audit records are swept separately: they are different policy
+// rows, the audit purge has to open and close the append-only window from
+// migration 153, and a failure in one must not abort the other.
+const pool = require('../config/database');
+const { log } = require('../utils/logger');
+const { runRetentionCleanup, runAuditLogRetention } = require('./jobService');
+
+let schedulerHandle = null;
+
+async function runRetentionSweep() {
+  try {
+    const orgsWithPolicy = await pool.query(
+      `SELECT DISTINCT organization_id
+         FROM data_retention_policies
+        WHERE active = true
+          AND auto_enforce = true
+          AND resource_type = 'evidence'`
+    );
+
+    let totalRemoved = 0;
+    for (const row of orgsWithPolicy.rows) {
+      try {
+        const result = await runRetentionCleanup({ organizationId: row.organization_id });
+        totalRemoved += result.removed || 0;
+      } catch (error) {
+        log('error', 'retention.sweep.org_failed', {
+          organizationId: row.organization_id,
+          error: error.message
+        });
+      }
+    }
+
+    if (orgsWithPolicy.rows.length > 0) {
+      log('info', 'retention.sweep.completed', {
+        organizations: orgsWithPolicy.rows.length,
+        removed: totalRemoved
+      });
+    }
+
+    // AU-11: audit records.
+    const orgsWithAuditPolicy = await pool.query(
+      `SELECT DISTINCT organization_id
+         FROM data_retention_policies
+        WHERE active = true
+          AND auto_enforce = true
+          AND resource_type = 'audit_logs'`
+    );
+
+    let auditRemoved = 0;
+    for (const row of orgsWithAuditPolicy.rows) {
+      try {
+        const result = await runAuditLogRetention({ organizationId: row.organization_id });
+        auditRemoved += result.removed || 0;
+      } catch (error) {
+        log('error', 'retention.audit_sweep.org_failed', {
+          organizationId: row.organization_id,
+          error: error.message
+        });
+      }
+    }
+
+    if (orgsWithAuditPolicy.rows.length > 0) {
+      log('info', 'retention.audit_sweep.completed', {
+        organizations: orgsWithAuditPolicy.rows.length,
+        removed: auditRemoved
+      });
+    }
+  } catch (error) {
+    log('error', 'retention.sweep.failed', { error: error.message });
+  }
+}
+
+function startRetentionScheduler() {
+  const enabled = (process.env.ENABLE_RETENTION_ENFORCEMENT || 'true').toLowerCase() !== 'false';
+  if (!enabled) {
+    log('info', 'retention.scheduler.disabled');
+    return () => {};
+  }
+
+  if (!pool.isConfigured) {
+    log('info', 'retention.scheduler.skipped', { reason: 'database_not_configured' });
+    return () => {};
+  }
+
+  const parsedInterval = Number(process.env.RETENTION_SWEEP_INTERVAL_HOURS);
+  const intervalHours = Number.isFinite(parsedInterval) ? Math.max(1, parsedInterval) : 24;
+  const intervalMs = intervalHours * 60 * 60 * 1000;
+
+  runRetentionSweep();
+  schedulerHandle = setInterval(runRetentionSweep, intervalMs);
+
+  log('info', 'retention.scheduler.started', { intervalHours });
+
+  return () => {
+    if (schedulerHandle) {
+      clearInterval(schedulerHandle);
+      schedulerHandle = null;
+      log('info', 'retention.scheduler.stopped');
+    }
+  };
+}
+
+module.exports = {
+  startRetentionScheduler,
+  runRetentionSweep
+};

--- a/docs/FEDRAMP_DEPLOYMENT_GUIDE.md
+++ b/docs/FEDRAMP_DEPLOYMENT_GUIDE.md
@@ -79,11 +79,12 @@ All secrets must be injected via environment variables — never hardcoded in so
 | `RATE_LIMIT_WINDOW_MS` | `900000` | 15-minute window |
 | `RATE_LIMIT_MAX` | `100` | Requests per window per IP |
 
-> **AU-11 retention is not configurable through the application.** An
-> `AUDIT_LOG_RETENTION_DAYS` variable was previously listed here; no such
-> variable is read anywhere in the codebase and setting it has no effect.
-> Audit-record retention must be enforced outside the platform — see the
-> AU-11 row in section 5.
+> **Audit-record retention** is configured with a `data_retention_policies`
+> row of `resource_type = 'audit_logs'`, not an environment variable. An
+> `AUDIT_LOG_RETENTION_DAYS` variable was previously recommended here; no
+> such variable was ever read by any code. `AUDIT_LOG_MIN_RETENTION_DAYS`
+> (default 365) sets the floor a policy cannot go below. See the AU-11 row
+> in section 5.
 
 ---
 
@@ -148,13 +149,13 @@ do not claim them on the strength of this table.
 | AU-2 | Partial | Events are recorded to `audit_logs.event_type`. Most routes write through `services/auditService.js`, but a number of route handlers issue their own `INSERT INTO audit_logs` with a narrower column set, so field coverage is not uniform across event types. `event_type` is free-text — there is no enforced event registry. |
 | AU-3 | Partial | Recorded per event: `event_type`, `created_at`, `user_id`, `actor_name`, `organization_id`, `resource_type`, `resource_id`, `ip_address`, `user_agent`, `success`, `outcome`, `failure_reason`, `request_id`, `source_system`. **Not recorded as columns:** HTTP method and request path (captured only inside the `details` JSONB by `middleware/auditLog.js`), and before/after values. `authentication_method` is populated for authentication events only (set explicitly by `auditService.logAuthentication`/`logLogout`); `session_id` has no writer at all — the platform issues stateless JWTs carrying no session identifier, so use `request_id` for per-request correlation. Both columns are documented as such in the schema. |
 | AU-4 | **Deployer-supplied** | No audit-log storage-capacity monitoring or alerting exists. Monitor table growth and provision storage externally. |
-| AU-5 | **Deployer-supplied** | No response to audit-logging failures. A failed audit write is written to the process stdout/stderr stream and the originating request still succeeds; these writes do not reach the structured logger or Sentry. Alerting on audit-pipeline failure must be supplied externally. |
+| AU-5 | Implemented | Audit-write and SIEM-forward failures are reported through the structured logger (`audit.write_failed`, `audit.siem_forward_failed`), so they reach Sentry rather than being swallowed to the console, and are counted per process and surfaced on the operations dashboard as `audit_pipeline`. That counter is deliberately separate from `failures_24h`, which counts audited business events that failed — only `audit_pipeline` tells you the trail itself is incomplete. Routing those alerts to a pager or ticket queue remains deployer-supplied. |
 | AU-6 | Implemented | `GET /api/v1/audit/logs` with filtering by user, event type, resource, and date range; `GET /api/v1/audit/stats`; dashboard audit trail at `/dashboard/audit`. Optional SIEM forwarding via `services/siemService.js`. |
-| AU-7 | Partial | Filtering and event-type aggregation are available through the endpoints above. There is no audit-record export endpoint — auditors must pull through the API or the database. |
+| AU-7 | Implemented | `GET /api/v1/audit/export` returns CSV or JSON under `audit.read`, accepting the same filters as `GET /audit/logs` (including a new `outcome` filter) and streaming in keyset batches so a multi-year export is not held in memory. CSV cells are RFC 4180 escaped and formula-prefixed. Each export is itself recorded as an `audit.exported` event. |
 | AU-8 | Implemented | `audit_logs.created_at` is `timestamptz` (migration 152), set server-side by `NOW()` and never supplied by the caller, so every record is unambiguously mappable to UTC. Time synchronization (NTP) on the database host remains deployer-supplied. |
 | AU-9 | Partial | Append-only is enforced in the database by the triggers in migration `153`: `DELETE` and `TRUNCATE` are rejected, and `UPDATE` is rejected for every column except `siem_forwarded`. Row-level security (`FORCE`, migration `105`) provides tenant isolation. This is tamper-**resistant**, not tamper-**evident** — there is no hash chain or record signature, and the application owns the table, so a privileged code path can disable the trigger. Note also that `organization_id` is `ON DELETE CASCADE`, so deleting an organization still removes its audit history. FRH-AU-9(3) requires cryptographic integrity: supplement with write-once log shipping. |
 | AU-10 | Partial | `user_id`, `actor_name`, and `ip_address` are recorded on records written through `auditService`. Note `user_id` is `ON DELETE SET NULL`, so deleting a user detaches the identity from historical records (`actor_name` is retained). No digital signature is applied; FRH-AU-10 requires one — supplement with an external signing service. |
-| AU-11 | **Deployer-supplied** | No retention period is enforced for `audit_logs`. The `data_retention_policies` table lists `audit_logs` as an intended `resource_type`, but the retention scheduler acts on evidence only. Records accumulate indefinitely. |
+| AU-11 | Implemented | `data_retention_policies` rows with `resource_type = 'audit_logs'` are now enforced by the retention sweep. Two safeguards apply: a floor (`AUDIT_LOG_MIN_RETENTION_DAYS`, default 365, never below a hard 90-day floor) so a policy cannot be set low enough to erase the trail within policy, and an active legal hold on `audit_logs` suspends the purge entirely. The purge opens the append-only window inside a single transaction and writes an `audit.retention_purge` record, so the deletion is visible in the trail it modified. Set the policy to 1095 days for FedRAMP High. |
 | AU-12 | Partial | Audit records are generated by route handlers calling `auditService`. The `middleware/auditLog.js` wrapper — the only path that records HTTP method and path — is mounted on a single router (`routes/dataSovereignty.js`) and fires only on 2xx responses, so it does not record failed operations. |
 
 Critical event types that must be logged (verify these exist in your deployment):

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -469,6 +469,20 @@ export const auditAPI = {
   getStats: (params: { startDate?: string; endDate?: string }) =>
     api.get('/audit/stats', { params }),
 
+  // AU-7. Returns the raw response as a Blob so the caller can hand it
+  // straight to a download; the endpoint streams, so this must not be parsed
+  // as JSON for the CSV format.
+  exportLogs: (params: {
+    format?: 'csv' | 'json';
+    userId?: string;
+    eventType?: string;
+    resourceType?: string;
+    resourceId?: string;
+    outcome?: string;
+    startDate?: string;
+    endDate?: string;
+  }) => api.get('/audit/export', { params, responseType: 'blob' }),
+
   getEventTypes: () => api.get('/audit/event-types'),
 
   getUserLogs: (userId: string) => api.get(`/audit/user/${userId}`),


### PR DESCRIPTION
## Description

Third PR of the AU control family remediation. #268 corrected the false claims and #269 added append-only enforcement; this one implements the three controls that had **no platform implementation at all** and were marked *Deployer-supplied*.

> **Stacked on #269.** Base is `…-au-hardening`. GitHub retargets automatically as the stack merges.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 💥 Breaking change (fix or feature that changes existing behavior)
- [ ] 📝 Documentation update
- [ ] 🎨 Code style / refactor (no functional changes)
- [ ] 🧪 Tests
- [ ] 🔧 CI/CD / tooling

## Changes Made

**AU-5 — Response to Audit Logging Process Failures.** Every audit-write and SIEM-forward failure was a `console.error` followed by a swallow. Per this repo's own `.claude/rules/logging.md` there is **no console bridge**, so those writes reached neither the structured log stream nor Sentry — a broken audit pipeline was completely invisible. Those paths now use `log('error', …)` with `serializeError` and increment a per-process counter surfaced on the ops dashboard as `audit_pipeline`.

That counter is deliberately separate from the existing `failures_24h` tile, which counts audited *business* events that failed; only the new one can tell an operator the *trail itself* is incomplete. Write failures also feed `open_issue_count`.

**AU-7 — Audit Record Reduction and Report Generation.** Adds `GET /audit/export` (CSV or JSON) under `requirePermission('audit.read')`, streaming in keyset batches of 1000 so a multi-year export is not buffered. The nine filter conditions were extracted into a shared `buildAuditFilterClause` used by both `/logs` and `/export` — an export that silently selects a different population than the screen the auditor was looking at would be worse than no export. The refactor adds an **`outcome` filter** that `/logs` did not offer, despite `outcome` being the field an assessor filters on first. CSV cells are RFC 4180 escaped and formula-prefixed so a spreadsheet cannot evaluate an audit value. Each export is recorded as an `audit.exported` event. A mid-stream failure destroys the response rather than ending it cleanly, so a truncated file is not mistaken for a complete one.

**AU-11 — Audit Record Retention.** `data_retention_policies` has always named `audit_logs` as an intended `resource_type`, but enforcement only queried evidence. `runAuditLogRetention` honors those rows with two safeguards evidence retention does not need:

- **A floor.** Retention settable arbitrarily low is a delete button — set one day, wait, and the trail is gone *within policy*. `AUDIT_LOG_MIN_RETENTION_DAYS` (default 365) sets it per deployment, with a hard 90-day floor no policy or environment variable can go below. Applying the floor is logged.
- **Trigger coordination.** Purging necessarily opens the append-only window added in #269's migration 153. It is held inside one transaction so a failure rolls the protection back on, and the purge writes an `audit.retention_purge` record in that same transaction — so the deletion is visible in the trail it modified, and a rollback discards the claim along with it.

An active legal hold on `audit_logs` suspends the purge entirely rather than deleting around it.

**Retention sweep ported.** This repo had **no retention scheduler at all** — `jobService.runRetentionCleanup` existed and was correct, but nothing invoked it, so even *evidence* retention only ran if an operator enqueued the job by hand. `services/retentionScheduler.js` is ported from the sibling ControlWeaver-Pro repository and wired into `server.js` alongside the reminder and report schedulers, with audit policies swept in a separate pass. Without this, AU-11 here would have been a capability rather than an enforced control. This does mean the PR also starts enforcing pre-existing evidence retention policies that were previously inert — worth knowing before merge.

**Frontend** `api.ts` gains `auditAPI.exportLogs`, returning a Blob so the CSV stream is not parsed as JSON.

## Testing

- [x] Checked that existing functionality is not broken
- [ ] Tested backend endpoints manually — not run in this environment
- [ ] Ran database migrations and seed scripts — not run in this environment

```bash
cd backend && npm run check:syntax   # Syntax check passed for 266 files.
```

**What I have not verified, stated plainly:**

- **Unit suite not seen passing.** `npx jest` fails with `Cannot find module '@babel/preset-env'` across all 19 suites including untouched files — devDependencies are not installed here, so `npx` fetches its own jest. Environmental, but I have not seen it green.
- **Frontend typecheck unreliable** — `node_modules` is absent, so every import resolves to `Cannot find module`. The `api.ts` errors are all pre-existing `axios` cascades at lines before the added method.
- **Nothing executed against a live database.** The retention purge needs a real run:

```sql
-- a 1-day policy must NOT purge inside the 90-day hard floor
INSERT INTO data_retention_policies (organization_id, resource_type, retention_days, active, auto_enforce)
VALUES ('<org>', 'audit_logs', 1, true, true);
-- after the sweep: nothing below the floor removed, an audit.retention_purge row exists,
-- and the trigger is back on:
UPDATE audit_logs SET event_type = 'x' WHERE id = (SELECT id FROM audit_logs LIMIT 1);  -- expect insufficient_privilege
```

## Checklist

- [x] My branch follows the naming convention
- [x] My code follows the existing code style
- [x] I've added comments for complex logic
- [x] I've updated documentation if needed
- [x] I've checked for SQL injection / security issues — all new queries parameterized; the only non-parameterized fragment is the `LIMIT ${BATCH}` constant in the export batcher
- [x] I've not introduced any hardcoded secrets or API keys
- [x] This PR is focused
- [ ] I've updated `RELEASE_NOTES.md` — release-notes automation generates the entry on merge

## Additional Notes

AU-5, AU-7 and AU-11 move from **Deployer-supplied**/Partial to **Implemented** in the FedRAMP guide. The note under the environment-variable table is corrected again: retention *is* now configurable, just through a `data_retention_policies` row rather than the `AUDIT_LOG_RETENTION_DAYS` variable that never existed.

**Remaining in the series:** AU-3 field coverage is still uneven across the ~40 direct `INSERT INTO audit_logs` call sites (next PR), and AU-9 remains tamper-*resistant* rather than tamper-*evident* — hash chaining comes after that.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkY9DTQSdAX1NV4Se9KWpE)_